### PR TITLE
Persistency

### DIFF
--- a/.godocdown.md
+++ b/.godocdown.md
@@ -35,8 +35,8 @@
     )
 
     // group even the route configuration which will be used in routes.Add
-    func NewMockResource() (string, string, *MockResource) {
-        return "TestId", "/test/{id}", &MockResource{}
+    func NewMockResource() (string, string, func() rest.ResourceType) {
+        return "TestId", "/test/{id}", func() rest.ResourceType { return &MockResource{} }
     }
 
     func (c *MockResource) Get() {
@@ -49,30 +49,31 @@
     	fmt.Fprintf(c.Response, ResponseMock)
     }
 
-    func (c *MockResource) Post() (status int, body interface{}) {
-    	return, http.StatusOK, ResponseMockPOST
+    func (c *MockResource) Post() {
+      fmt.Println(http.StatusOK)
+      fmt.Println(ResponseMockPOST)
     }
 
-    func (c *MockResource) Put() (status int, body interface{}) {
-    	return, http.StatusOK, ResponseMockPUT
+    func (c *MockResource) Put() {
+      fmt.Println(http.StatusOK)
+      fmt.Println(ResponseMockPUT)
     }
 
-    func (c *MockResource) Patch() (status int, body interface{}) {
-      return, http.StatusOK, ResponseMockPATCH
+    func (c *MockResource) Patch() {
+      fmt.Println(http.StatusOK)
+      fmt.Println(ResponseMockPATCH)
     }
 
-    func (c *MockResource) Delete() (status int, body interface{}) {
-    	return, http.StatusOK, ResponseMockDELETE
+    func (c *MockResource) Delete() {
+      fmt.Println(http.StatusOK)
+      fmt.Println(ResponseMockDELETE)
     }
 
-    func (c *MockResource) Options() (status int, body interface{}) {
-    	return, http.StatusOK, ResponseMockOPTIONS
+    func (c *MockResource) Options() {
+      fmt.Println(http.StatusOK)
+      fmt.Println(ResponseMockOPTIONS)
     }
 
-    func (c *MockResource) Done(status int, body interface{}) {
-      fmt.Println(status)
-      fmt.Println(body)
-    }
 
 `mock2_resource.go`
 
@@ -94,17 +95,13 @@
     	ResponseMock2 = "FooBarSub"
     )
 
-    func NewMock2Resource() (string, string, *Mock2Resource) {
-        return "Test", "/test2", &Mock2Resource
+    func NewMock2Resource() (string, string, func() rest.ResourceType) {
+        return "Test", "/test2", func() rest.ResourceType { return &Mock2Resource{} }
     }
 
-    func (c *Mock2Resource) Get() (status int, body interface{}) {
-    	return, http.StatusOK, ResponseMock2
-    }
-
-    func (c *MockResource) Done(status int, body interface{}) {
-      fmt.Println(status)
-      fmt.Println(body)
+    func (c *Mock2Resource) Get() {
+      fmt.Println(http.StatusOK)
+      fmt.Println(ResponseMock2)
     }
 
 

--- a/.godocdown.md
+++ b/.godocdown.md
@@ -24,6 +24,16 @@
     	rest.Resource
     }
 
+    const (
+    	ResponseMock           = "FooBar"
+    	ResponseMockPOST       = "FooBarPOST"
+    	ResponseMockPUT        = "FooBarPUT"
+    	ResponseMockPATCH      = "FooBarPATCH"
+    	ResponseMockOPTIONS    = "FooBarOPTIONS"
+    	ResponseMockDELETE     = "FooBarDELETE"
+    	ResponseMockWithParams = "FooBar1"
+    )
+
     // group even the route configuration which will be used in routes.Add
     func NewMockResource() (string, string, *MockResource) {
         return "TestId", "/test/{id}", &MockResource{}
@@ -39,26 +49,30 @@
     	fmt.Fprintf(c.Response, ResponseMock)
     }
 
-    func (c *MockResource) Post() {
-    	fmt.Fprintf(c.Response, ResponseMockPOST)
+    func (c *MockResource) Post() (status int, body interface{}) {
+    	return, http.StatusOK, ResponseMockPOST
     }
 
-    func (c *MockResource) Put() {
-    	fmt.Fprintf(c.Response, ResponseMockPUT)
+    func (c *MockResource) Put() (status int, body interface{}) {
+    	return, http.StatusOK, ResponseMockPUT
     }
 
-    func (c *MockResource) Patch() {
-    	fmt.Fprintf(c.Response, ResponseMockPATCH)
+    func (c *MockResource) Patch() (status int, body interface{}) {
+      return, http.StatusOK, ResponseMockPATCH
     }
 
-    func (c *MockResource) Delete() {
-    	fmt.Fprintf(c.Response, ResponseMockDELETE)
+    func (c *MockResource) Delete() (status int, body interface{}) {
+    	return, http.StatusOK, ResponseMockDELETE
     }
 
-    func (c *MockResource) Options() {
-    	fmt.Fprintf(c.Response, ResponseMockOPTIONS)
+    func (c *MockResource) Options() (status int, body interface{}) {
+    	return, http.StatusOK, ResponseMockOPTIONS
     }
 
+    func (c *MockResource) Done(status int, body interface{}) {
+      fmt.Println(status)
+      fmt.Println(body)
+    }
 
 `mock2_resource.go`
 
@@ -76,13 +90,20 @@
     	rest.Resource
     }
 
+    const (
+    	ResponseMock2          = "FooBarSub"
+
     func NewMock2Resource() (string, string, *Mock2Resource) {
         return "Test", "/test2", &Mock2Resource
     }
 
-    func (c *Mock2Resource) Get() {
-    	c.Response.WriteHeader(http.StatusOK)
-    	fmt.Fprintf(c.Response, ResponseMock2)
+    func (c *Mock2Resource) Get() (status int, body interface{}) {
+    	return, http.StatusOK, ResponseMock2
+    }
+
+    func (c *MockResource) Done(status int, body interface{}) {
+      fmt.Println(status)
+      fmt.Println(body)
     }
 
 

--- a/.godocdown.md
+++ b/.godocdown.md
@@ -91,7 +91,8 @@
     }
 
     const (
-    	ResponseMock2          = "FooBarSub"
+    	ResponseMock2 = "FooBarSub"
+    )
 
     func NewMock2Resource() (string, string, *Mock2Resource) {
         return "Test", "/test2", &Mock2Resource

--- a/README.md
+++ b/README.md
@@ -65,24 +65,24 @@ func (c *Resource) Defer()
 Defer is triggered after all execution (including Deinit() and faulty
 executions)
 
-#### func (*Resource) Deinit
-
-```go
-func (c *Resource) Deinit()
-```
-Deinit method that finalizes the Resource
-
 #### func (*Resource) Delete
 
 ```go
-func (c *Resource) Delete()
+func (c *Resource) Delete() (status int, body interface{})
 ```
 Delete represents http.delete
+
+#### func (*Resource) Done
+
+```go
+func (c *Resource) Done(status int, body interface{})
+```
+Done method that finalizes the Resource
 
 #### func (*Resource) Get
 
 ```go
-func (c *Resource) Get()
+func (c *Resource) Get() (status int, body interface{})
 ```
 Get represents http.get
 
@@ -97,28 +97,28 @@ the method and proceed to deinit()
 #### func (*Resource) Options
 
 ```go
-func (c *Resource) Options()
+func (c *Resource) Options() (status int, body interface{})
 ```
 Options represents http.options
 
 #### func (*Resource) Patch
 
 ```go
-func (c *Resource) Patch()
+func (c *Resource) Patch() (status int, body interface{})
 ```
 Patch represents http.patch
 
 #### func (*Resource) Post
 
 ```go
-func (c *Resource) Post()
+func (c *Resource) Post() (status int, body interface{})
 ```
 Post represents http.post
 
 #### func (*Resource) Put
 
 ```go
-func (c *Resource) Put()
+func (c *Resource) Put() (status int, body interface{})
 ```
 Put represents http.put
 
@@ -144,19 +144,19 @@ type ResourceType interface {
 
 	Init() bool
 
-	Get()
+	Get() (status int, body interface{})
 
-	Put()
+	Put() (status int, body interface{})
 
-	Post()
+	Post() (status int, body interface{})
 
-	Patch()
+	Patch() (status int, body interface{})
 
-	Options()
+	Options() (status int, body interface{})
 
-	Delete()
+	Delete() (status int, body interface{})
 
-	Deinit()
+	Done(status int, body interface{})
 
 	Defer()
 	// contains filtered or unexported methods

--- a/README.md
+++ b/README.md
@@ -68,21 +68,21 @@ executions)
 #### func (*Resource) Delete
 
 ```go
-func (c *Resource) Delete() (status int, body interface{})
+func (c *Resource) Delete()
 ```
 Delete represents http.delete
 
 #### func (*Resource) Done
 
 ```go
-func (c *Resource) Done(status int, body interface{})
+func (c *Resource) Done()
 ```
 Done method that finalizes the Resource
 
 #### func (*Resource) Get
 
 ```go
-func (c *Resource) Get() (status int, body interface{})
+func (c *Resource) Get()
 ```
 Get represents http.get
 
@@ -97,28 +97,28 @@ the method and proceed to deinit()
 #### func (*Resource) Options
 
 ```go
-func (c *Resource) Options() (status int, body interface{})
+func (c *Resource) Options()
 ```
 Options represents http.options
 
 #### func (*Resource) Patch
 
 ```go
-func (c *Resource) Patch() (status int, body interface{})
+func (c *Resource) Patch()
 ```
 Patch represents http.patch
 
 #### func (*Resource) Post
 
 ```go
-func (c *Resource) Post() (status int, body interface{})
+func (c *Resource) Post()
 ```
 Post represents http.post
 
 #### func (*Resource) Put
 
 ```go
-func (c *Resource) Put() (status int, body interface{})
+func (c *Resource) Put()
 ```
 Put represents http.put
 
@@ -144,19 +144,19 @@ type ResourceType interface {
 
 	Init() bool
 
-	Get() (status int, body interface{})
+	Get()
 
-	Put() (status int, body interface{})
+	Put()
 
-	Post() (status int, body interface{})
+	Post()
 
-	Patch() (status int, body interface{})
+	Patch()
 
-	Options() (status int, body interface{})
+	Options()
 
-	Delete() (status int, body interface{})
+	Delete()
 
-	Done(status int, body interface{})
+	Done()
 
 	Defer()
 	// contains filtered or unexported methods
@@ -169,10 +169,10 @@ ResourceType represents an interface information about a rest resource.
 
 ```go
 type Route struct {
-	Name     string
-	Pattern  string
-	Resource ResourceType
-	Server   *Server
+	Name                 string
+	Pattern              string
+	ResourceInstantiator func() ResourceType
+	Server               *Server
 }
 ```
 
@@ -211,7 +211,7 @@ NewRoutes simplifies the initialization of the routes.
 #### func (Routes) Add
 
 ```go
-func (rs Routes) Add(name string, pattern string, c ResourceType) Routes
+func (rs Routes) Add(name string, pattern string, resourceInstantiator func() ResourceType) Routes
 ```
 Add a new Route to the stack
 
@@ -291,9 +291,19 @@ SetRoutes set the Routes given the array of route
     	rest.Resource
     }
 
+    const (
+    	ResponseMock           = "FooBar"
+    	ResponseMockPOST       = "FooBarPOST"
+    	ResponseMockPUT        = "FooBarPUT"
+    	ResponseMockPATCH      = "FooBarPATCH"
+    	ResponseMockOPTIONS    = "FooBarOPTIONS"
+    	ResponseMockDELETE     = "FooBarDELETE"
+    	ResponseMockWithParams = "FooBar1"
+    )
+
     // group even the route configuration which will be used in routes.Add
-    func NewMockResource() (string, string, *MockResource) {
-        return "TestId", "/test/{id}", &MockResource{}
+    func NewMockResource() (string, string, func() rest.ResourceType) {
+        return "TestId", "/test/{id}", func() rest.ResourceType { return &MockResource{} }
     }
 
     func (c *MockResource) Get() {
@@ -307,23 +317,28 @@ SetRoutes set the Routes given the array of route
     }
 
     func (c *MockResource) Post() {
-    	fmt.Fprintf(c.Response, ResponseMockPOST)
+      fmt.Println(http.StatusOK)
+      fmt.Println(ResponseMockPOST)
     }
 
     func (c *MockResource) Put() {
-    	fmt.Fprintf(c.Response, ResponseMockPUT)
+      fmt.Println(http.StatusOK)
+      fmt.Println(ResponseMockPUT)
     }
 
     func (c *MockResource) Patch() {
-    	fmt.Fprintf(c.Response, ResponseMockPATCH)
+      fmt.Println(http.StatusOK)
+      fmt.Println(ResponseMockPATCH)
     }
 
     func (c *MockResource) Delete() {
-    	fmt.Fprintf(c.Response, ResponseMockDELETE)
+      fmt.Println(http.StatusOK)
+      fmt.Println(ResponseMockDELETE)
     }
 
     func (c *MockResource) Options() {
-    	fmt.Fprintf(c.Response, ResponseMockOPTIONS)
+      fmt.Println(http.StatusOK)
+      fmt.Println(ResponseMockOPTIONS)
     }
 
 
@@ -343,13 +358,17 @@ SetRoutes set the Routes given the array of route
     	rest.Resource
     }
 
-    func NewMock2Resource() (string, string, *Mock2Resource) {
-        return "Test", "/test2", &Mock2Resource
+    const (
+    	ResponseMock2 = "FooBarSub"
+    )
+
+    func NewMock2Resource() (string, string, func() rest.ResourceType) {
+        return "Test", "/test2", func() rest.ResourceType { return &Mock2Resource{} }
     }
 
     func (c *Mock2Resource) Get() {
-    	c.Response.WriteHeader(http.StatusOK)
-    	fmt.Fprintf(c.Response, ResponseMock2)
+      fmt.Println(http.StatusOK)
+      fmt.Println(ResponseMock2)
     }
 
 

--- a/mock_test.go
+++ b/mock_test.go
@@ -26,7 +26,7 @@ type MockResource struct {
 	Param string
 }
 
-func (c MockResource) Get() {
+func (c *MockResource) Get() (status int, body interface{}) {
 	c.Response.WriteHeader(http.StatusOK)
 	if o := c.Request.URL.Query().Get("out"); "" != o {
 		c.Param = o
@@ -43,26 +43,32 @@ func (c MockResource) Get() {
 	}
 
 	fmt.Fprintf(c.Response, ResponseMock)
+	return status, body
 }
 
-func (c MockResource) Post() {
+func (c *MockResource) Post() (status int, body interface{}) {
 	fmt.Fprintf(c.Response, ResponseMockPOST)
+	return status, body
 }
 
-func (c MockResource) Put() {
+func (c *MockResource) Put() (status int, body interface{}) {
 	fmt.Fprintf(c.Response, ResponseMockPUT)
+	return status, body
 }
 
-func (c MockResource) Patch() {
+func (c *MockResource) Patch() (status int, body interface{}) {
 	fmt.Fprintf(c.Response, ResponseMockPATCH)
+	return status, body
 }
 
-func (c MockResource) Delete() {
+func (c *MockResource) Delete() (status int, body interface{}) {
 	fmt.Fprintf(c.Response, ResponseMockDELETE)
+	return status, body
 }
 
-func (c MockResource) Options() {
+func (c *MockResource) Options() (status int, body interface{}) {
 	fmt.Fprintf(c.Response, ResponseMockOPTIONS)
+	return status, body
 }
 
 // Another Mock Resource
@@ -70,19 +76,21 @@ type Mock2Resource struct {
 	rest.Resource
 }
 
-func (c Mock2Resource) Get() {
+func (c *Mock2Resource) Get() (status int, body interface{}) {
 	c.Response.WriteHeader(http.StatusOK)
 	fmt.Fprintf(c.Response, ResponseMock2)
+	return status, body
 }
 
 type MockJSONResource struct {
 	rest.Resource
 }
 
-func (c MockJSONResource) Get() {
+func (c *MockJSONResource) Get() (status int, body interface{}) {
 	c.Response.WriteHeader(http.StatusOK)
 	c.SetContentType(rest.ContentTypeTextPlain)
 	fmt.Fprintf(c.Response, `{"foo":"bar"}`)
+	return status, body
 }
 
 func GetHandlerResponse(resource rest.ResourceType, method string) *http.Response {

--- a/mock_test.go
+++ b/mock_test.go
@@ -26,7 +26,7 @@ type MockResource struct {
 	Param string
 }
 
-func (c *MockResource) Get() (status int, body interface{}) {
+func (c *MockResource) Get() {
 	c.Response.WriteHeader(http.StatusOK)
 	if o := c.Request.URL.Query().Get("out"); "" != o {
 		c.Param = o
@@ -43,32 +43,26 @@ func (c *MockResource) Get() (status int, body interface{}) {
 	}
 
 	fmt.Fprintf(c.Response, ResponseMock)
-	return status, body
 }
 
-func (c *MockResource) Post() (status int, body interface{}) {
+func (c *MockResource) Post() {
 	fmt.Fprintf(c.Response, ResponseMockPOST)
-	return status, body
 }
 
-func (c *MockResource) Put() (status int, body interface{}) {
+func (c *MockResource) Put() {
 	fmt.Fprintf(c.Response, ResponseMockPUT)
-	return status, body
 }
 
-func (c *MockResource) Patch() (status int, body interface{}) {
+func (c *MockResource) Patch() {
 	fmt.Fprintf(c.Response, ResponseMockPATCH)
-	return status, body
 }
 
-func (c *MockResource) Delete() (status int, body interface{}) {
+func (c *MockResource) Delete() {
 	fmt.Fprintf(c.Response, ResponseMockDELETE)
-	return status, body
 }
 
-func (c *MockResource) Options() (status int, body interface{}) {
+func (c *MockResource) Options() {
 	fmt.Fprintf(c.Response, ResponseMockOPTIONS)
-	return status, body
 }
 
 // Another Mock Resource
@@ -76,21 +70,19 @@ type Mock2Resource struct {
 	rest.Resource
 }
 
-func (c *Mock2Resource) Get() (status int, body interface{}) {
+func (c *Mock2Resource) Get() {
 	c.Response.WriteHeader(http.StatusOK)
 	fmt.Fprintf(c.Response, ResponseMock2)
-	return status, body
 }
 
 type MockJSONResource struct {
 	rest.Resource
 }
 
-func (c *MockJSONResource) Get() (status int, body interface{}) {
+func (c *MockJSONResource) Get() {
 	c.Response.WriteHeader(http.StatusOK)
 	c.SetContentType(rest.ContentTypeTextPlain)
 	fmt.Fprintf(c.Response, `{"foo":"bar"}`)
-	return status, body
 }
 
 func GetHandlerResponse(resource rest.ResourceType, method string) *http.Response {
@@ -98,7 +90,7 @@ func GetHandlerResponse(resource rest.ResourceType, method string) *http.Respons
 }
 
 func GetServerHandlerResponse(resource rest.ResourceType, method string, s *rest.Server) *http.Response {
-	route := rest.Route{Resource: resource}
+	route := rest.Route{ResourceInstantiator: func() rest.ResourceType { return resource }}
 	handler := route.GetHandler(s)
 
 	w := httptest.NewRecorder()

--- a/mock_test.go
+++ b/mock_test.go
@@ -23,10 +23,20 @@ const (
 // Mock Resource
 type MockResource struct {
 	rest.Resource
+	Param string
 }
 
-func (c *MockResource) Get() {
+func (c MockResource) Get() {
 	c.Response.WriteHeader(http.StatusOK)
+	if o := c.Request.URL.Query().Get("out"); "" != o {
+		c.Param = o
+	}
+
+	if c.Param != "" {
+		fmt.Fprintf(c.Response, c.Param)
+		return
+	}
+
 	if c.Vars["id"] != "" {
 		fmt.Fprintf(c.Response, ResponseMockWithParams)
 		return
@@ -35,23 +45,23 @@ func (c *MockResource) Get() {
 	fmt.Fprintf(c.Response, ResponseMock)
 }
 
-func (c *MockResource) Post() {
+func (c MockResource) Post() {
 	fmt.Fprintf(c.Response, ResponseMockPOST)
 }
 
-func (c *MockResource) Put() {
+func (c MockResource) Put() {
 	fmt.Fprintf(c.Response, ResponseMockPUT)
 }
 
-func (c *MockResource) Patch() {
+func (c MockResource) Patch() {
 	fmt.Fprintf(c.Response, ResponseMockPATCH)
 }
 
-func (c *MockResource) Delete() {
+func (c MockResource) Delete() {
 	fmt.Fprintf(c.Response, ResponseMockDELETE)
 }
 
-func (c *MockResource) Options() {
+func (c MockResource) Options() {
 	fmt.Fprintf(c.Response, ResponseMockOPTIONS)
 }
 
@@ -60,7 +70,7 @@ type Mock2Resource struct {
 	rest.Resource
 }
 
-func (c *Mock2Resource) Get() {
+func (c Mock2Resource) Get() {
 	c.Response.WriteHeader(http.StatusOK)
 	fmt.Fprintf(c.Response, ResponseMock2)
 }
@@ -69,7 +79,7 @@ type MockJSONResource struct {
 	rest.Resource
 }
 
-func (c *MockJSONResource) Get() {
+func (c MockJSONResource) Get() {
 	c.Response.WriteHeader(http.StatusOK)
 	c.SetContentType(rest.ContentTypeTextPlain)
 	fmt.Fprintf(c.Response, `{"foo":"bar"}`)

--- a/resource.go
+++ b/resource.go
@@ -18,19 +18,19 @@ type ResourceType interface {
 
 	Init() bool
 
-	Get() (status int, body interface{})
+	Get()
 
-	Put() (status int, body interface{})
+	Put()
 
-	Post() (status int, body interface{})
+	Post()
 
-	Patch() (status int, body interface{})
+	Patch()
 
-	Options() (status int, body interface{})
+	Options()
 
-	Delete() (status int, body interface{})
+	Delete()
 
-	Done(status int, body interface{})
+	Done()
 
 	Defer()
 }
@@ -67,15 +67,13 @@ func (c *Resource) set(self ResourceType, vars map[string]string, w http.Respons
 	}
 
 	defer metCall("Defer")
-	//rc.Method
 
-	var response []reflect.Value
 	if false != metCall("Init")[0].Bool() {
 		// Call HTTP Method using Camelcase
-		response = metCall(r.Method[0:1] + strings.ToLower(r.Method)[1:])
+		metCall(r.Method[0:1] + strings.ToLower(r.Method)[1:])
 	}
 
-	metCall("Done", response...)
+	metCall("Done")
 }
 
 // SetContentType method to set the content type
@@ -95,43 +93,37 @@ func (c *Resource) Init() bool {
 }
 
 // Get represents http.get
-func (c *Resource) Get() (status int, body interface{}) {
+func (c *Resource) Get() {
 	c.SetStatus(http.StatusMethodNotAllowed)
-	return status, body
 }
 
 // Put represents http.put
-func (c *Resource) Put() (status int, body interface{}) {
+func (c *Resource) Put() {
 	c.SetStatus(http.StatusMethodNotAllowed)
-	return status, body
 }
 
 // Post represents http.post
-func (c *Resource) Post() (status int, body interface{}) {
+func (c *Resource) Post() {
 	c.SetStatus(http.StatusMethodNotAllowed)
-	return status, body
 }
 
 // Patch represents http.patch
-func (c *Resource) Patch() (status int, body interface{}) {
+func (c *Resource) Patch() {
 	c.SetStatus(http.StatusMethodNotAllowed)
-	return status, body
 }
 
 // Options represents http.options
-func (c *Resource) Options() (status int, body interface{}) {
+func (c *Resource) Options() {
 	c.SetStatus(http.StatusMethodNotAllowed)
-	return status, body
 }
 
 // Delete represents http.delete
-func (c *Resource) Delete() (status int, body interface{}) {
+func (c *Resource) Delete() {
 	c.SetStatus(http.StatusMethodNotAllowed)
-	return status, body
 }
 
 // Done method that finalizes the Resource
-func (c *Resource) Done(status int, body interface{}) {}
+func (c *Resource) Done() {}
 
 // Defer is triggered after all execution (including Deinit() and faulty executions)
 func (c *Resource) Defer() {}

--- a/route.go
+++ b/route.go
@@ -11,10 +11,10 @@ import (
 
 // Route represents the struct of Route
 type Route struct {
-	Name     string
-	Pattern  string
-	Resource ResourceType
-	Server   *Server
+	Name                 string
+	Pattern              string
+	ResourceInstantiator func() ResourceType
+	Server               *Server
 }
 
 // Routes represents a array/collection of Route
@@ -38,11 +38,11 @@ func NewRoutes() Routes {
 }
 
 // Add a new Route to the stack
-func (rs Routes) Add(name string, pattern string, c ResourceType) Routes {
+func (rs Routes) Add(name string, pattern string, resourceInstantiator func() ResourceType) Routes {
 	rs.stack = append(rs.stack, Route{
-		Name:     name,
-		Pattern:  pattern,
-		Resource: c,
+		Name:                 name,
+		Pattern:              pattern,
+		ResourceInstantiator: resourceInstantiator,
 	})
 
 	return rs
@@ -82,6 +82,8 @@ func (r Route) GetHandler(s *Server) func(http.ResponseWriter, *http.Request) {
 			}
 		}()
 
-		r.Resource.set(r.Resource, mux.Vars(rq), w, rq, l, r)
+		resource := r.ResourceInstantiator()
+
+		resource.set(resource, mux.Vars(rq), w, rq, l, r)
 	}
 }

--- a/route_test.go
+++ b/route_test.go
@@ -61,7 +61,7 @@ func TestGetHandlerWithNilServer(t *testing.T) {
 		}
 	}()
 
-	route := rest.Route{Resource: new(MockResource)}
+	route := rest.Route{ResourceInstantiator: func() rest.ResourceType { return new(MockResource) }}
 	route.GetHandler(nil)
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -39,8 +39,8 @@ func ExampleServer() {
 	s.SetRoutes(
 		mux.NewRouter().StrictSlash(true),
 		rest.NewRoutes().
-			Add("Test", "/test2", &Mock2Resource{}).
-			Add("TestId", "/test/{id}", &MockResource{}).
+			Add("Test", "/test2", func() rest.ResourceType { return &Mock2Resource{} }).
+			Add("TestId", "/test/{id}", func() rest.ResourceType { return &MockResource{} }).
 			Root(func(w http.ResponseWriter, r *http.Request) {
 				fmt.Fprint(w, ResponseRoot)
 			}).
@@ -91,9 +91,12 @@ func ExampleServer() {
 			break
 		}
 	}
-	fmt.Println(<-chanBody)
+	go fn("", chanBody)
+	fmt.Println(<-chanBody) // regular response
+	fmt.Println(<-chanBody) // persistency check response
 	// Output:
 	// ThisIsReST
+	// FooBar1
 }
 
 func TestEmptyHandler(t *testing.T) {

--- a/server_test.go
+++ b/server_test.go
@@ -39,8 +39,8 @@ func ExampleServer() {
 	s.SetRoutes(
 		mux.NewRouter().StrictSlash(true),
 		rest.NewRoutes().
-			Add("Test", "/test2", new(Mock2Resource)).
-			Add("TestId", "/test/{id}", new(MockResource)).
+			Add("Test", "/test2", &Mock2Resource{}).
+			Add("TestId", "/test/{id}", &MockResource{}).
 			Root(func(w http.ResponseWriter, r *http.Request) {
 				fmt.Fprint(w, ResponseRoot)
 			}).
@@ -84,18 +84,16 @@ func ExampleServer() {
 		c <- string(bytesBody)
 	}
 
-	go fn("?out=a", chanBody)
+	go fn("?out=ThisIsReST", chanBody)
 	for i := 0; i < waitForResponse; i++ {
 		time.Sleep(10 * time.Millisecond)
 		if err == nil {
 			break
 		}
 	}
-	go fn("", chanBody)
-	fmt.Println(<-chanBody)
 	fmt.Println(<-chanBody)
 	// Output:
-	// FooBarTest
+	// ThisIsReST
 }
 
 func TestEmptyHandler(t *testing.T) {


### PR DESCRIPTION
Issue: When a property is set in the *Resource, it does not "reset" in other API calls that use the same resource. This will cause issues such as inconsistent and unpredictable property values.